### PR TITLE
binwalk does not start if python3 capstone bindings are installed [fixing python3 --disas option (using compat dict iterator)]

### DIFF
--- a/src/binwalk/modules/disasm.py
+++ b/src/binwalk/modules/disasm.py
@@ -5,12 +5,12 @@ from binwalk.core.module import Module, Option, Kwarg
 
 class ArchResult(object):
     def __init__(self, **kwargs):
-        for (k,v) in kwargs.iteritems():
+        for (k,v) in binwalk.core.compat.iterator(kwargs):
             setattr(self, k, v)
 
 class Architecture(object):
     def __init__(self, **kwargs):
-        for (k, v) in kwargs.iteritems():
+        for (k, v) in binwalk.core.compat.iterator(kwargs):
             setattr(self, k, v)
 
 class Disasm(Module):


### PR DESCRIPTION
currently binwalk is broken and refuses to do anything if python3 capstone bindings are installed as it tries to call 'iteritems' on a dictionary (which was removed in python3)

> binwalk --help
Traceback (most recent call last):
  File "/usr/bin/binwalk", line 26, in <module>
    import binwalk.modules
  File "/usr/lib/python3.4/site-packages/binwalk/modules/__init__.py", line 3, in <module>
    from binwalk.modules.disasm import Disasm
  File "/usr/lib/python3.4/site-packages/binwalk/modules/disasm.py", line 16, in <module>
    class Disasm(Module):
  File "/usr/lib/python3.4/site-packages/binwalk/modules/disasm.py", line 50, in Disasm
    description="ARM executable code, 32-bit, big endian"),
  File "/usr/lib/python3.4/site-packages/binwalk/modules/disasm.py", line 13, in __init__
    for (k, v) in kwargs.iteritems():
AttributeError: 'dict' object has no attribute 'iteritems'


the script 'modules/disasm.py' already imports 'import binwalk.core.compat' so the fix is replacing 'iteritems' with 'binwalk.core.compat.iterator(kwargs)'