### PR TITLE
Fixed TRX v1 signature bug

### DIFF
--- a/src/binwalk/magic/firmware
+++ b/src/binwalk/magic/firmware
@@ -102,8 +102,9 @@
 >>24    ulelong       x       rootfs offset: 0x%X,
 >>28    ulelong       x       bin-header offset: 0x%X,
 >14     uleshort      1       version: %d,
->>16    ulelong       x       kernel offset: 0x%X,
->>20    ulelong       x       rootfs offset: 0x%X
+>>16    ulelong       x       loader offset: 0x%X,
+>>20    ulelong       x       linux kernel offset: 0x%X,
+>>24    ulelong       x       rootfs offset: 0x%X,
 
 # Ubicom firmware image
 0       belong    0xFA320080    Ubicom firmware header,


### PR DESCRIPTION
The signature for the TRX header is still incomplete for v1. According to http://wiki.openwrt.org/doc/techref/header, offset[0] = lzma-loader, offset[1] = Linux-Kernel and offset[2] = rootfs.

Before the fix:

bernardomr@splinter ~/openwrt $ binwalk openwrt-wrtsl54gs-squashfs.bin 

DECIMAL       HEXADECIMAL     DESCRIPTION
32            0x20            TRX firmware header, little endian, header size: 32 bytes, image size: 1323008 bytes, CRC32: 0x6CAC483, flags: 0x0, version: 1, kernel offset: 0x1C, rootfs offset: 0x8D8
60            0x3C            gzip compressed data, maximum compression, from Unix, NULL date:
2296          0x8F8           LZMA compressed data, properties: 0x6D, dictionary size: 8388608 bytes, uncompressed size: -1 bytes
517152        0x7E420         Squashfs filesystem, little endian, version 2.1, size: 805671 bytes, 269 inodes, blocksize: 65536 bytes, created: 2014-10-29 18:53:25

After the fix:

bernardomr@splinter ~/openwrt $ binwalk openwrt-wrtsl54gs-squashfs.bin 

DECIMAL       HEXADECIMAL     DESCRIPTION
32            0x20            TRX firmware header, little endian, header size: 32 bytes, image size: 1323008 bytes, CRC32: 0x6CAC483, flags: 0x0, version: 1, loader offset: 0x1C, linux kernel offset: 0x8D8, rootfs offset: 0x7E400,
60            0x3C            gzip compressed data, maximum compression, from Unix, NULL date:
2296          0x8F8           LZMA compressed data, properties: 0x6D, dictionary size: 8388608 bytes, uncompressed size: -1 bytes
517152        0x7E420         Squashfs filesystem, little endian, version 2.1, size: 805671 bytes, 269 inodes, blocksize: 65536 bytes, created: 2014-10-29 18:53:25

- Loader: 0x20 + 0x1C = 0x3C
- Kernel: 0x20 + 0x8D8 = 0x8F8
- RootFS: 0x20 + 0x7E400 = 0x7E420