### PR TITLE
TRX Header Size Fix

### DIFF
--- a/src/binwalk/magic/firmware
+++ b/src/binwalk/magic/firmware
@@ -89,22 +89,22 @@
 >48     string        x         root device: "%s"
 
 # trx image file
-0       string        HDR0    TRX firmware header, little endian, header size: 32 bytes,
+0       string        HDR0    TRX firmware header, little endian,
 >4      lelong        <1      {invalid}
 >4      ulelong       x       image size: %d bytes,
 >8      ulelong       x       CRC32: 0x%X,
 >12     uleshort      x       flags: 0x%X,
 >14     uleshort      !1
 >>14    uleshort      !2      {invalid}
->14     uleshort      2       version: %d,
+>14     uleshort      2       version: %d, header size: 32 bytes,
 >>16    ulelong       x       loader offset: 0x%X,
 >>20    ulelong       x       linux kernel offset: 0x%X,
 >>24    ulelong       x       rootfs offset: 0x%X,
->>28    ulelong       x       bin-header offset: 0x%X,
->14     uleshort      1       version: %d,
+>>28    ulelong       x       bin-header offset: 0x%X
+>14     uleshort      1       version: %d, header size: 28 bytes,
 >>16    ulelong       x       loader offset: 0x%X,
 >>20    ulelong       x       linux kernel offset: 0x%X,
->>24    ulelong       x       rootfs offset: 0x%X,
+>>24    ulelong       x       rootfs offset: 0x%X
 
 # Ubicom firmware image
 0       belong    0xFA320080    Ubicom firmware header,


### PR DESCRIPTION
Header from TRX v1 has 28 bytes while TRX v2 has 32 bytes.