### PR TITLE
explicitly attempt both byte-orderings with sasquatch

### DIFF
--- a/src/binwalk/config/extract.conf
+++ b/src/binwalk/config/extract.conf
@@ -41,7 +41,8 @@
 
 # Try unsquashfs first, or if not installed, sasquatch
 ^squashfs filesystem:squashfs:unsquashfs -d '%%squashfs-root%%' '%e':0:False
-^squashfs filesystem:squashfs:sasquatch -d '%%squashfs-root%%' '%e':0:False
+^squashfs filesystem:squashfs:sasquatch -d -le '%%squashfs-root%%' '%e':0:False
+^squashfs filesystem:squashfs:sasquatch -d -be '%%squashfs-root%%' '%e':0:False
 
 # Try cramfsck first; if that fails, swap the file system and try again
 ^cramfs filesystem:cramfs:cramfsck -x '%%cramfs-root%%' '%e':0:False


### PR DESCRIPTION
Currently, with some firmware images, `sasquatch` will attempt to auto-detect firmware endianess, and fail because the heuristic is not always correct. Instead, modify `binwalk` to explicitly attempt both byte-orderings with `sasquatch`.