### PR TITLE
fix previous commit that modified sasquatch arguments (ab2ace76dd3521c39394e4f3daf8dfbfe2d464d3)

### DIFF
--- a/src/binwalk/config/extract.conf
+++ b/src/binwalk/config/extract.conf
@@ -41,8 +41,8 @@
 
 # Try unsquashfs first, or if not installed, sasquatch
 ^squashfs filesystem:squashfs:unsquashfs -d '%%squashfs-root%%' '%e':0:False
-^squashfs filesystem:squashfs:sasquatch -d -le '%%squashfs-root%%' '%e':0:False
-^squashfs filesystem:squashfs:sasquatch -d -be '%%squashfs-root%%' '%e':0:False
+^squashfs filesystem:squashfs:sasquatch -le -d '%%squashfs-root%%' '%e':0:False
+^squashfs filesystem:squashfs:sasquatch -be -d '%%squashfs-root%%' '%e':0:False
 
 # Try cramfsck first; if that fails, swap the file system and try again
 ^cramfs filesystem:cramfs:cramfsck -x '%%cramfs-root%%' '%e':0:False


### PR DESCRIPTION
the arguments to sasquatch were being passed in wrong order, which broke extraction. the endianness flag should come before the `-d <pathname>` argument.