### PR TITLE
add signature for encrypted qnap firmware

### DIFF
--- a/src/binwalk/magic/firmware
+++ b/src/binwalk/magic/firmware
@@ -610,10 +610,17 @@
 >>(&0.L+4)      belong      x                       \b, file size: %d bytes
 
 # Another Broadcom firmware header...
-# The header seems to be always 0x100 bytes lenght and there is more information than the one displayed (not sure about the meaning).
+# The header seems to be always 0x100 bytes length and there is more information than the one displayed (not sure about the meaning).
 # Used for example in the EchoLife HG556a router
 0x0	string 	\x38\x00\x00\x00	Broadcom firmware header
 >0x4	string	!Broadcom Corporatio	{invalid}
 >0x18	string	x			%s.
 >0x8E	string	x			Model: %s.
 >0xA2	string	x			Firmware version: %s.
+
+# QNAP encrypted firmware
+0       string       icpnas                  QNAP encrypted firmware footer
+>10     string       x                       , model: %s
+>26     string       x                       , version: %s
+>42     uleshort     !0
+>>42    string       x                       , date: %s


### PR DESCRIPTION
Unfortunately, QNAP encrypted firmware can be identified only by a footer (and not a header), but there is no easy way in binwalk (that I could find) to check a negative-offset signature before positive-offset signatures. So this signature is suboptimal, because it will only trigger after searching through the entire file.