### PR TITLE
Fix Exception when exporting Entropy graph as PNG image.

### DIFF
--- a/src/binwalk/modules/entropy.py
+++ b/src/binwalk/modules/entropy.py
@@ -312,7 +312,7 @@ class Entropy(Module):
             try:
                 exporter = exporters.ImageExporter(plt.plotItem)
             except TypeError:
-                exporter = exporters.ImageExporter.ImageExporter(plt.plotItem)
+                exporter = exporters.ImageExporter(plt.plotItem)
             exporter.parameters()['width'] = self.FILE_WIDTH
             exporter.export(binwalk.core.common.unique_file_name(out_file, self.FILE_FORMAT))
         else:


### PR DESCRIPTION
Fixes: `Entropy Exception: type object 'ImageExporter' has no attribute 'ImageExporter'` message after running `binwalk -EJ firmware.bin`

For reference: `pyqtgraph` version is currently at `0.9.10`.

```
Entropy Exception: type object 'ImageExporter' has no attribute 'ImageExporter'
----------------------------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/binwalk/core/module.py", line 499, in main
    retval = self.run()
  File "/usr/local/lib/python2.7/site-packages/binwalk/modules/entropy.py", line 94, in run
    self.calculate_file_entropy(fp)
Help on class ImageExporter in module pyqtgraph.exporters.ImageExporter:

class ImageExporter(pyqtgraph.exporters.Exporter.Exporter)
 |  Method resolution order:
 |      ImageExporter
 |      pyqtgraph.exporters.Exporter.Exporter
 |      __builtin__.object
 |
 |  Methods defined here:
 |
 |  __init__(self, item)
 |
 |  export(self, fileName=None, toBytes=False, copy=False)
 |
 |  heightChanged(self)
 |
 |  parameters(self)
 |
 |  widthChanged(self)
 |
 |  ----------------------------------------------------------------------
 |  Data and other attributes defined here:
 |
 |  Name = 'Image File (PNG, TIF, JPG, ...)'
 |
 |  allowCopy = True
 |
 |  ----------------------------------------------------------------------
 |  Methods inherited from pyqtgraph.exporters.Exporter.Exporter:
 |
 |  fileSaveDialog(self, filter=None, opts=None)
 |
 |  fileSaveFinished(self, fileName)
 |
 |  getPaintItems(self, root=None)
 |      Return a list of all items that should be painted in the correct order.
 |
 |  getScene(self)
 |
 |  getSourceRect(self)
 |
 |  getTargetRect(self)
 |
 |  render(self, painter, targetRect, sourceRect, item=None)
 |
 |  setExportMode(self, export, opts=None)
 |      Call setExportMode(export, opts) on all items that will
 |      be painted during the export. This informs the item
 |      that it is about to be painted for export, allowing it to
 |      alter its appearance temporarily
Help on class ImageExporter in module pyqtgraph.exporters.ImageExporter:

class ImageExporter(pyqtgraph.exporters.Exporter.Exporter)
 |  Method resolution order:
 |      ImageExporter
  File "/usr/local/lib/python2.7/site-packages/binwalk/modules/entropy.py", line 121, in calculate_file_entropy
    self.plot_entropy(fp.name)
  File "/usr/local/lib/python2.7/site-packages/binwalk/modules/entropy.py", line 199, in plot_entropy
    exporter = exporters.ImageExporter.ImageExporter(plt.plotItem)
AttributeError: type object 'ImageExporter' has no attribute 'ImageExporter'
----------------------------------------------------------------------------------------------------
```