### PR TITLE
fixed typo which breaks recursive extraction

### DIFF
--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -192,7 +192,7 @@ class Extractor(Module):
                     # If recursion was specified, and the file is not the same one we just dd'd
                     if self.matryoshka and file_path != dd_file_path and scan_extracted_files:
                         # If the recursion level of this file is less than or equal to our desired recursion level
-                        if len(real_file_path.split(self.directory)[1].split(os.path.sep)) <= self.matryoshka:
+                        if len(real_file_path.split(self.directory)[0].split(os.path.sep)) <= self.matryoshka:
                             # If this is a directory and we are supposed to process directories for this extractor,
                             # then add all files under that directory to the list of pending files.
                             if os.path.isdir(file_path):


### PR DESCRIPTION
real_file_path.split(self.directory)[1].split(os.path.sep) results in the following error:
Signature Exception: list index out of range
----------------------------------------------------------------------------------------------------
Traceback (most recent call last):
      File "/usr/local/lib/python2.7/dist-packages/binwalk/core/module.py", line 541, in main
          retval = self.run()
        File "/usr/local/lib/python2.7/dist-packages/binwalk/modules/signature.py", line 177, in run
          self.scan_file(fp)
        File "/usr/local/lib/python2.7/dist-packages/binwalk/modules/signature.py", line 160, in scan_file
          self.result(r=r)
        File "/usr/local/lib/python2.7/dist-packages/binwalk/core/module.py", line 431, in result
          getattr(self, dependency.attribute).callback(r)
        File "/usr/local/lib/python2.7/dist-packages/binwalk/modules/extractor.py", line 195, in callback
          if len(real_file_path.split(self.directory)[1].split(os.path.sep)) <= self.matryoshka:
      IndexError: list index out of range
      ----------------------------------------------------------------------------------------------------
