### PR TITLE
use internal lzmaextract for xz and 7z as an alternative

### DIFF
--- a/src/binwalk/config/extract.conf
+++ b/src/binwalk/config/extract.conf
@@ -20,13 +20,14 @@
 #
 #   o gzip
 #   o lzma
+#   o xz
 #
 #######################################################################################################################################
 
 # Assumes these utilities are installed in $PATH.
 ^gzip compressed data:gz:gzip -d -f '%e':0,2
 ^lzma compressed data:7z:7z e -y '%e':0,1
-^xz compressed data:tar:tar xJf '%e'
+^xz compressed data:xz:7z e -y '%e':0,1
 ^bzip2 compressed data:bz2:bzip2 -d '%e'
 ^compress'd data:Z:gzip -d '%e'
 ^zip archive data:zip:7z x -y '%e' -p '':0,1

--- a/src/binwalk/plugins/lzmaextract.py
+++ b/src/binwalk/plugins/lzmaextract.py
@@ -12,6 +12,7 @@ class LZMAExtractPlugin(binwalk.core.plugin.Plugin):
             # lzma package in Python 2.0 decompress() does not handle multiple
             # compressed streams, only first stream is extracted.
             # backports.lzma package could be used to keep consistent behaviour.
+            import lzma
             self.decompressor = lzma.decompress
 
             # If the extractor is enabled for the module we're currently loaded

--- a/src/binwalk/plugins/lzmaextract.py
+++ b/src/binwalk/plugins/lzmaextract.py
@@ -9,7 +9,9 @@ class LZMAExtractPlugin(binwalk.core.plugin.Plugin):
 
     def init(self):
         try:
-            import lzma
+            # lzma package in Python 2.0 decompress() does not handle multiple
+            # compressed streams, only first stream is extracted.
+            # backports.lzma package could be used to keep consistent behaviour.
             self.decompressor = lzma.decompress
 
             # If the extractor is enabled for the module we're currently loaded
@@ -18,6 +20,10 @@ class LZMAExtractPlugin(binwalk.core.plugin.Plugin):
                 self.module.extractor.add_rule(txtrule=None,
                                                regex="^lzma compressed data",
                                                extension="7z",
+                                               cmd=self.extractor)
+                self.module.extractor.add_rule(txtrule=None,
+                                               regex="^xz compressed data",
+                                               extension="xz",
                                                cmd=self.extractor)
         except ImportError as e:
             pass


### PR DESCRIPTION
use internal lzmaextract for xz and 7z as an alternative (tar can only handle tar.xz archives).
Example: http://downloads.linksys.com/downloads/firmware/1224703410530/FW_RE4100W_v1.0.00.008_20141009.bin