### PR TITLE
Fix typo preventing apt dependency install

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -o nounset
+set -o errexit
 
 REQUIRED_UTILS="wget tar python"
 APTCMD="apt-get"
@@ -144,7 +146,7 @@ fi
 
 # Do the install(s)
 cd /tmp
-sudo $PKGCMD $PKGCMD_OPTS $PKG_CANDIDTES
+sudo $PKGCMD $PKGCMD_OPTS $PKG_CANDIDATES
 install_pip_package pyqtgraph
 install_pip_package capstone
 install_sasquatch

--- a/deps.sh
+++ b/deps.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -o nounset
-set -o errexit
 
 REQUIRED_UTILS="wget tar python"
 APTCMD="apt-get"


### PR DESCRIPTION
I found the problem with the apt dependencies not being installed - one character out of place!

I've also added `set -o nounset` to help prevent further bugs like this.