### PR TITLE
deps: check for package installation failure

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -146,6 +146,11 @@ fi
 # Do the install(s)
 cd /tmp
 sudo $PKGCMD $PKGCMD_OPTS $PKG_CANDIDATES
+if [ $? -ne 0 ]
+    then
+    echo "Package installation failed: $PKG_CANDIDATES"
+    exit 1
+fi
 install_pip_package pyqtgraph
 install_pip_package capstone
 install_sasquatch


### PR DESCRIPTION
Certain Debian-based distribution like Kali Linux 2016.1 don't include `cramfsprogs` in the package repository. This causes `deps.sh` to fail when installing packages, but since this return value isn't checked, the errors will propagate and `sasquatch` will fail to compile, for example, if the system is also missing `zlib1g-dev`. Checking the return value of the package installation command fixes this, though more generally `set -o errexit` also works. Unfortunately, passing the `-m` parameter to `apt-get` for `--ignore-missing` doesn't work, because packages with no installation candidate produce an invalid command, instead of missing packages.