### PR TITLE
Ignore dotfiles when discovering magic files

### DIFF
--- a/src/binwalk/core/settings.py
+++ b/src/binwalk/core/settings.py
@@ -65,12 +65,16 @@ class Settings:
         user_binarch = self._user_path(self.BINWALK_MAGIC_DIR, self.BINARCH_MAGIC_FILE)
         system_binarch = self._system_path(self.BINWALK_MAGIC_DIR, self.BINARCH_MAGIC_FILE)
 
+        def list_files(dir_path):
+            # Restrict files list to names starting with an alphanumeric
+            return [os.path.join(dir_path, x) for x in os.listdir(dir_path) if x[0].isalnum()]
+
         if not system_only:
             user_dir = os.path.join(self.user_dir, self.BINWALK_USER_DIR, self.BINWALK_MAGIC_DIR)
-            files += [os.path.join(user_dir, x) for x in os.listdir(user_dir)]
+            files += list_files(user_dir)
         if not user_only:
             system_dir = os.path.join(self.system_dir, self.BINWALK_MAGIC_DIR)
-            files += [os.path.join(system_dir, x) for x in os.listdir(system_dir)]
+            files += list_files(system_dir)
 
         # Don't include binarch signatures in the default list of signature files.
         # It is specifically loaded when -A is specified on the command line.

--- a/src/binwalk/core/settings.py
+++ b/src/binwalk/core/settings.py
@@ -66,8 +66,8 @@ class Settings:
         system_binarch = self._system_path(self.BINWALK_MAGIC_DIR, self.BINARCH_MAGIC_FILE)
 
         def list_files(dir_path):
-            # Restrict files list to names starting with an alphanumeric
-            return [os.path.join(dir_path, x) for x in os.listdir(dir_path) if x[0].isalnum()]
+            # Ignore hidden dotfiles.
+            return [os.path.join(dir_path, x) for x in os.listdir(dir_path) if not x.startswith('.')]
 
         if not system_only:
             user_dir = os.path.join(self.user_dir, self.BINWALK_USER_DIR, self.BINWALK_MAGIC_DIR)


### PR DESCRIPTION
I was a bit surprised to get an "UnicodeDecodeError: 'utf-8' codec can't
decode byte 0xbe in position 21: invalid start byte" error while
writing and testing a new magic file.

It turns out that binwalk tried to parse the Vim swap file (.magic.swp)
as a magic file which obviously fails. Therefore ignore all files not
starting with an alphanumeric character.
___
The check could be made even stronger such that files like `magic.orig`, `magic.dpkg-old` or `magic.pacnew` are ignored, but this is already a good start I guess. Maybe the plugin path discovery needs a similar fix?