### PR TITLE
Fix custom output directory for extracted files

### DIFF
--- a/src/binwalk/modules/extractor.py
+++ b/src/binwalk/modules/extractor.py
@@ -102,8 +102,11 @@ class Extractor(Module):
     def load(self):
         # Holds a list of extraction rules loaded either from a file or when manually specified.
         self.extract_rules = []
-        # The input file specific output directory path (to be determined at runtime)
-        self.directory = None
+        # The input file specific output directory path (default to CWD)
+        if self.base_directory:
+            self.directory = os.path.realpath(self.base_directory)
+        else:
+            self.directory = os.getcwd()
         # Key value pairs of input file path and output extraction path
         self.output = {}
         # Number of extracted files
@@ -425,10 +428,6 @@ class Extractor(Module):
         if not has_key(self.extraction_directories, path):
             basedir = os.path.dirname(path)
             basename = os.path.basename(path)
-
-            # Make sure we put the initial extraction directory in the CWD
-            if self.directory is None:
-                self.directory = os.getcwd()
 
             if basedir != self.directory:
                 # During recursive extraction, extracted files will be in subdirectories


### PR DESCRIPTION
Fixes regression since 5fdad3c5ffe63efc1f0b213a56dd962477f7190f which ignored the -C option and wrote all files in the current working directory.

Tested with:

    touch foo && gzip foo && mkdir bar
    binwalk -e foo.gz -C bar
    binwalk -e foo.gz