### PR TITLE
Update kwarg processing to ensure modules don't receive a mutable reference to defaults

### DIFF
--- a/src/binwalk/core/module.py
+++ b/src/binwalk/core/module.py
@@ -10,6 +10,7 @@ import time
 import inspect
 import argparse
 import traceback
+from copy import copy
 import binwalk.core.statuserver
 import binwalk.core.common
 import binwalk.core.settings
@@ -901,7 +902,7 @@ class Modules(object):
                 if has_key(kwargs, module_argument.name):
                     arg_value = kwargs[module_argument.name]
                 else:
-                    arg_value = module_argument.default
+                    arg_value = copy(module_argument.default)
 
                 setattr(obj, module_argument.name, arg_value)
 


### PR DESCRIPTION
Fixes #207 , also the Signature module was "leaking" memory.

The `Signature` module `magic_files` attribute is initialized via kwarg.  When no `magic_files` argument is specified (the default mode), it receives a reference to the default empty list. During Signature's init() method, this list is modified, and because it is modifying the class variable default, it continues to grow every time the Signature module executes. This causes a long-running binwalk process to appear to leak memory and the duplicate signatures cause each subsequent iteration of `binwalk.scan` to run slower.

```
import binwalk
import binwalk.modules
from binwalk.modules import Signature
from binwalk.core.module import Modules

magic_files = [k for k in binwalk.modules.Signature.KWARGS if k.name=="magic_files"][0]

m = Modules("/usr/bin/ls", signature=True, quiet=True)
for x in range(0,10):
   r = m.execute()[0]
   print('%d %d' % (len(magic_files.default), len(r.magic_files)))
```

