### PR TITLE
adding MPEG transport stream signatures to magic/animations

### DIFF
--- a/src/binwalk/magic/animation
+++ b/src/binwalk/magic/animation
@@ -1,0 +1,16 @@
+0       string  \x47\x40\x00    MPEG transport stream data
+>3	byte&0x10		!0x10		{invalid}
+>188	byte			!0x47		{invalid}
+
+0       string  \x47\xC0\x00    MPEG transport stream data
+>3	byte&0x10		!0x10		{invalid}
+>188	byte			!0x47		{invalid}
+
+0       string  \x47\x60\x00    MPEG transport stream data
+>3	byte&0x10		!0x10		{invalid}
+>188	byte			!0x47		{invalid}
+
+0       string  \x47\xE0\x00    MPEG transport stream data
+>3	byte&0x10		!0x10		{invalid}
+>188	byte			!0x47		{invalid}
+


### PR DESCRIPTION
As you suggested in issue 225, multiple magic bytes makes detection of these MPEG transport streams work.