### PR TITLE
Zip footer signature accurately reflects its size

### DIFF
--- a/src/binwalk/magic/archives
+++ b/src/binwalk/magic/archives
@@ -48,7 +48,8 @@
 >30     string      x               name: {string}%s
 
 # ZIP footer
-0       string      PK\x05\x06      End of Zip archive
+0       string      PK\x05\x06      End of Zip archive,
+>20     leshort+22  x               footer length: %d
 >20     leshort     >0
 >>20    leshort     x               \b, comment:
 >>20    leshort     x               {strlen:%d}


### PR DESCRIPTION
See: https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html

The previous zip footer signature only displayed comment length without the added footer (End of central directory record.) This was potentially confusing when trying to dd out an archive.