### PR TITLE
Strengthening TAR signature.

### DIFF
--- a/src/binwalk/magic/archives
+++ b/src/binwalk/magic/archives
@@ -1,7 +1,7 @@
 # ----------------------------Archive Formats--------------------------------------
 
 # POSIX tar archives
-257     string      ustar\000   POSIX tar archive
+257     string      ustar\00000   POSIX tar archive
 >8      byte        !0
 >>8     string      x           \b, owner user name: "%.32s"
 >40     byte        !0


### PR DESCRIPTION
refs:
https://en.wikipedia.org/wiki/Tar_(computing)
https://www.gnu.org/software/tar/manual/html_node/Standard.html (see TVERSION)

The combination of a weak TAR signature and the tar.py plugin can lead to instances where a false-positive result has a "jump" value. This jump value could render further true-positive signatures invalid. This is particularly noticeable in firmware images that contain TAR parsers that do a string match on "ustar" themselves. 