### PR TITLE
Add the possibility of having user-defined modules (not only plugins for existing modules)

### DIFF
--- a/src/binwalk/core/module.py
+++ b/src/binwalk/core/module.py
@@ -673,6 +673,24 @@ class Modules(object):
             if inspect.isclass(module) and hasattr(module, attribute):
                 modules[module] = module.PRIORITY
 
+        # user-defined modules
+        import imp
+        user_modules = binwalk.core.settings.Settings().user.modules
+        for file_name in os.listdir(user_modules):
+            if not file_name.endswith('.py'):
+                continue
+            module_name = file_name[:-3]
+            try:
+                user_module = imp.load_source(module_name, os.path.join(user_modules, file_name))
+            except KeyboardInterrupt as e:
+                raise e
+            except Exception as e:
+                binwalk.core.common.warning("Error loading module '%s': %s" % (file_name, str(e)))
+
+            for (name, module) in inspect.getmembers(user_module):
+                if inspect.isclass(module) and hasattr(module, attribute):
+                    modules[module] = module.PRIORITY
+
         return sorted(modules, key=modules.get, reverse=True)
 
     def help(self):

--- a/src/binwalk/core/settings.py
+++ b/src/binwalk/core/settings.py
@@ -23,6 +23,7 @@ class Settings:
     BINWALK_USER_DIR = "binwalk"
     BINWALK_MAGIC_DIR = "magic"
     BINWALK_CONFIG_DIR = "config"
+    BINWALK_MODULES_DIR = "modules"
     BINWALK_PLUGINS_DIR = "plugins"
 
     # File names
@@ -43,6 +44,7 @@ class Settings:
         self.user = common.GenericContainer(binarch=self._user_path(self.BINWALK_MAGIC_DIR, self.BINARCH_MAGIC_FILE),
                                             magic=self._magic_signature_files(user_only=True),
                                             extract=self._user_path(self.BINWALK_CONFIG_DIR, self.EXTRACT_FILE),
+                                            modules=self._user_path(self.BINWALK_MODULES_DIR),
                                             plugins=self._user_path(self.BINWALK_PLUGINS_DIR))
 
 


### PR DESCRIPTION
With this patch you can put a custom module in $HOME/.config/binwalk/modules.
A minimal module would probably define TITLE, CLI, KWARGS, init, and run.
I made this patch because I am working on a CPU recognition technique based on statistical analysis. The current plugin system is not suited for a completely new type of analysis.