### PR TITLE
Xilinx FPGA bitstream

### DIFF
--- a/src/binwalk/magic/misc
+++ b/src/binwalk/magic/misc
@@ -79,3 +79,7 @@
 
 0       string      \x00\x53\x46\x48                                    OSX DMG image
 >0x38   string      !d\x00i\x00s\x00k\x00\x20\x00i\x00m\x00a\x00g\x00e  invalid{invalid)
+
+# Xilinx FPGA Bitstream
+# Ref: http://www.xilinx.com/support/answers/7891.html
+0       ubequad        0xffffffffaa995566  Xilinx Virtex/Spartan FPGA bitstream dummy + sync word


### PR DESCRIPTION
See http://www.xilinx.com/support/answers/7891.html

Xilinx FPGA bitstreams start with one or more dummy words (0xffffffff) and a sync word (0xaa995566). Tested on files for several Spartan targets.