### PR TITLE
Fix extra data mistakingly "extracted" from raw Deflate streams

### DIFF
--- a/src/binwalk/modules/compression.py
+++ b/src/binwalk/modules/compression.py
@@ -173,7 +173,7 @@ class Deflate(object):
                 if not data or dlen == 0:
                     break
                 else:
-                    in_data += data
+                    in_data += data[:dlen]
 
                 try:
                     out_data = zlib.decompress(binwalk.core.compat.str2bytes(in_data), -15)


### PR DESCRIPTION
Hi, I think there's a bug here.

Per the [BlockFile docstring](/devttys0/binwalk/blob/master/src/binwalk/core/common.py#L256), `read_block()` can return **more** than `dlen` bytes of data, by peeking, and this is intended feature.

However, we don't want the peek'd extra bytes injected into the stream being decompressed -- as the next `read_block()` call will pull them again!

Take a ~1.5 MiB deflated file to test: `binwalk -X` will extract a slighly larger file than a plain `zlib.decompress(-15)` would. (This, exactly, was how this bug bite me.)

Hope this fix is simple enough to be merged easily! Cheers.