### PR TITLE
Added ability to toggle binary flags through python kwargs

### DIFF
--- a/src/binwalk/core/module.py
+++ b/src/binwalk/core/module.py
@@ -665,19 +665,23 @@ class Modules(object):
     def __exit__(self, t, v, b):
         self.cleanup()
 
-    def _set_arguments(self, argv=[], kargv={}):
-        for (k, v) in iterator(kargv):
-            k = self._parse_api_opt(k)
-            if v not in [True, False, None]:
-                if not isinstance(v, list):
-                    v = [v]
-                for value in v:
-                    if not isinstance(value, str):
-                        value = str(bytes2str(value))
-                    argv.append(k)
-                    argv.append(value)
-            else:
-                argv.append(k)
+    def _set_arguments(self, argv=None, kargv=None):
+        if kargv:
+            for (k, v) in iterator(kargv):
+                    k = self._parse_api_opt(k)
+                    if v not in [True, False, None]:
+                        if not isinstance(v, list):
+                            v = [v]
+                        for value in v:
+                            if not isinstance(value, str):
+                                value = str(bytes2str(value))
+                            argv.append(k)
+                            argv.append(value)
+                    else:
+                        # Only append if the value is True; this allows for toggling values
+                        # by the function call.
+                        if v:
+                            argv.append(k)
 
         if not argv and not self.arguments:
             self.arguments = sys.argv[1:]


### PR DESCRIPTION
Currently, if you try calling 

`import binwalk

for module in binwalk.scan('f1.bin', signature=True, quiet=True):
    print("DONE")
`
then whether or not you pass [True, False, or None] to quiet (or any other binary flag, for that matter), it will take whatever the default Kwarg value is, because it only appends the kwarg name, not the value. This only appends the kwarg if it is set to True (as all kwargs default to False), so that it can actually be toggled programmatically from python.

The change to argv/kargv to 'None' was just a minor cleanup to avoid unsafe behavior; lists/dicts as default values will persist any values added to them across function calls. 

